### PR TITLE
Fix: Update dependencies to latest compatible versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ name = "envelope"
 path = "src/main.rs"
 
 [dependencies]
-dcbor = "^0.16.2"
-bc-ur = "^0.6.2"
-bc-envelope = "^0.24.0"
-bc-components = "^0.17.0"
-bc-rand = "^0.2.1"
-bc-xid = "^0.5.0"
+dcbor = "^0.17.1"
+bc-ur = "^0.7.0"
+bc-envelope = "^0.26.0"
+bc-components = "^0.19.0"
+bc-rand = "^0.3.0"
+bc-xid = "^0.6.0"
 
 clap = { version = "^4.4.3", features = ["derive", "unstable-styles"] }
 anyhow = "^1.0.0"


### PR DESCRIPTION
## Summary
- Fixes build errors due to incompatible dependency versions
- Updates all library dependencies to their latest compatible versions

## Problem
The project was failing to build with the current dependency versions due to incompatible trait implementations between `XIDDocument` and `EnvelopeEncodable`. Specifically, the error was:

```
error[E0599]: the method `into_envelope` exists for struct `XIDDocument`, but its trait bounds were not satisfied
  --> src/utils.rs:50:20
   |
50 |             Ok(doc.into_envelope())
   |                    ^^^^^^^^^^^^^
   |
  ::: /Users/christophera/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bc-xid-0.5.0/src/xid_document.rs:29:1
   |
29 | pub struct XIDDocument {
   | ---------------------- doesn't satisfy `XIDDocument: Into<bc_envelope::Envelope>` or `XIDDocument: bc_envelope::EnvelopeEncodable`
```

## Solution
Updated the following dependencies to their latest compatible versions:
- dcbor: 0.16.2 -> 0.17.1
- bc-ur: 0.6.2 -> 0.7.0
- bc-envelope: 0.24.0 -> 0.26.0
- bc-components: 0.17.0 -> 0.19.0
- bc-rand: 0.2.1 -> 0.3.0
- bc-xid: 0.5.0 -> 0.6.0

After updating the dependencies, the project builds successfully in both debug and release modes, and all tests pass.

## Test plan
- ✅ Builds successfully in debug mode
- ✅ Builds successfully in release mode
- ✅ All tests pass
- ✅ CLI functionality verified with `envelope --help`