### PR TITLE
README only: Improve installation instructions with best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,64 @@
 
 ## Installation
 
-To install from crates.io, run:
+### From crates.io (Recommended)
+
+To install the latest stable version from crates.io, run:
 
 ```bash
 cargo install bc-envelope-cli
 ```
 
-To install from source, clone this repo, change to its root directory and run:
+To install a specific version:
 
 ```bash
+cargo install bc-envelope-cli --version 0.12.0
+```
+
+### From Source
+
+When building from source, we **strongly recommend** building from a tagged release rather than the tip of the main branch, which may contain unstable code or breaking changes:
+
+```bash
+# Clone the repository
+git clone https://github.com/BlockchainCommons/bc-envelope-cli-rust.git
+cd bc-envelope-cli-rust
+
+# List available tags
+git tag -l
+
+# Checkout the most recent tag
+git checkout $(git describe --tags --abbrev=0)
+
+# Install the tool
+cargo install --path .
+```
+
+If you must build from the main branch, be aware that it may have dependency mismatches or other issues:
+
+```bash
+# Build without installing (debug build)
+cargo build
+
+# Test before installing
+cargo test
+
+# If all tests pass, you can install
 cargo install --path .
 ```
 
 Make sure your `~/.cargo/bin` directory is in your `PATH`.
+
+### Troubleshooting Build Issues
+
+If you encounter build problems:
+
+1. **Try debug build first**: `cargo build` instead of `cargo build --release`
+2. **Check dependency versions**: The main branch might require specific versions of dependencies
+3. **Verify compatible Rust version**: Run `rustc --version` to check your Rust version
+4. **Build from a release tag**: Tagged releases have been tested and should build properly
+
+For serious build issues, please open an issue on the GitHub repository with details about your environment and the errors you're seeing.
 
 ## Usage
 


### PR DESCRIPTION
## Problem Statement

Developers building from the tip of the main branch may encounter build failures, dependency mismatches, or other issues, especially when using `cargo build --release`. This is a common issue when building Rust projects from source, but the current README doesn't provide guidance on how to avoid or resolve these problems.

## Solution

This PR enhances the installation section of the README.md to:

1. **Emphasize building from tagged releases** rather than the main branch
   - Added step-by-step instructions for checking out the latest tag
   - Explained why this approach is more reliable

2. **Provide clearer installation options**
   - Organized into 'From crates.io' and 'From Source' sections
   - Added guidance for installing specific versions

3. **Add detailed troubleshooting guidance**
   - Recommend trying debug builds when release builds fail
   - Added tips on verifying dependencies and Rust versions
   - Suggested checking for tagged releases when encountering issues

4. **Explain build process differences**
   - Clarified that debug builds may succeed when release builds fail
   - Noted the potential for dependency mismatches on the main branch

## IMPORTANT: CHANGES SCOPE

This PR **ONLY** modifies the README.md file. No other files are changed:
- No code changes
- No dependency updates
- No build script changes
- Only documentation improvements

## Benefits

- **Improves developer experience** by helping them avoid and troubleshoot common build issues
- **Reduces support requests** related to build failures
- **Promotes best practices** for building from tagged releases
- **Sets clear expectations** about the stability of the main branch vs. released versions

This PR is part of an effort to make Blockchain Commons tools more accessible and easier to work with for developers.